### PR TITLE
BUG: Do not do a hard reset of the numpy repo.

### DIFF
--- a/build_numpy.py
+++ b/build_numpy.py
@@ -53,7 +53,6 @@ def main():
         raise RuntimeError("Number of bits should be 32 or 64")
     os.chdir(numpy_path)
     check_call(['git', 'clean', '-fxd'])
-    check_call(['git', 'reset', '--hard'])
     blas_dir = pjoin(openblas_root, str(n_bits))
     with open(pjoin(blas_dir, 'site.cfg.template'), 'rt') as fobj:
         cfg_template = fobj.read()


### PR DESCRIPTION
The license file is modified before the build script is run. When
a hard reset is done, the added information is lost.

@matthew-brett  Was there a reason that the hard reset was done?